### PR TITLE
Fix dependency

### DIFF
--- a/yui/src/button/meta/button.json
+++ b/yui/src/button/meta/button.json
@@ -1,7 +1,7 @@
 {
     "moodle-atto_fontfamily-button": {
         "requires": [
-            "node"
+            "moodle-editor_atto-plugin"
         ]
     }
 }


### PR DESCRIPTION
in Moodle 3.5.1, if we remove in editor_atto|toolbar "collapse = collapse",
 and fontfamily is first (style1 = fontfamily, title, bold, ..), we have in console:
"Error: extend failed, verify dependencies"
and JS crashed.